### PR TITLE
Add benchmark and weight stats logging

### DIFF
--- a/train_resnet.py
+++ b/train_resnet.py
@@ -11,6 +11,8 @@ import torchvision.transforms as transforms
 from torch.utils.data import DataLoader
 from torch.utils.tensorboard import SummaryWriter
 
+from typing import Optional, Dict
+
 
 device = 'cpu'
 if torch.cuda.is_available():
@@ -21,11 +23,18 @@ elif torch.backends.mps.is_available():
 device = torch.device(device)
 
 
-def train(model, trainloader, epochs=10):
+def train(
+    model: nn.Module,
+    trainloader: DataLoader,
+    regularizer: Optional[HierarchicalRegularizer] = None,
+    writer: Optional[SummaryWriter] = None,
+    epochs: int = 10,
+) -> None:
     model.train()
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
-    writer = SummaryWriter("runs/hierarchical_sparse")
+    if writer is None:
+        writer = SummaryWriter("runs/tmp")
 
     step = 0
     for epoch in range(epochs):
@@ -34,7 +43,9 @@ def train(model, trainloader, epochs=10):
             x, y = x.to(device), y.to(device)
             out = model(x)
             loss_ce = criterion(out, y)
-            regularization_loss = regularizer.forward(model)
+            regularization_loss = 0.0
+            if regularizer is not None:
+                regularization_loss = regularizer.forward(model)
 
             loss = loss_ce + regularization_loss
 
@@ -43,7 +54,7 @@ def train(model, trainloader, epochs=10):
             optimizer.step()
 
             writer.add_scalar("Loss/CE", loss_ce.item(), step)
-            writer.add_scalar("Loss/Reg", regularization_loss, step)
+            writer.add_scalar("Loss/Reg", float(regularization_loss), step)
             writer.add_scalar("Loss/Total", loss.item(), step)
             step += 1
 
@@ -54,45 +65,104 @@ def train(model, trainloader, epochs=10):
         print(f"Epoch {epoch+1}, Avg Loss: {total_loss / len(trainloader):.4f}")
     writer.close()
 
+
+def evaluate(model: nn.Module, testloader: DataLoader) -> float:
+    """Return classification accuracy in percentage."""
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for x, y in testloader:
+            x, y = x.to(device), y.to(device)
+            out = model(x)
+            preds = out.argmax(dim=1)
+            total += y.size(0)
+            correct += (preds == y).sum().item()
+    model.train()
+    return 100.0 * correct / total
+
+
+def weight_statistics(model: nn.Module, threshold: float = 1e-5) -> Dict[str, float]:
+    """Return counts of zero and near-zero weights."""
+    zeros = 0
+    near_zeros = 0
+    total = 0
+    for p in model.parameters():
+        data = p.detach().cpu()
+        total += data.numel()
+        zeros += (data == 0).sum().item()
+        near_zeros += ((data.abs() < threshold) & (data != 0)).sum().item()
+    return {
+        "total": total,
+        "zeros": zeros,
+        "near_zeros": near_zeros,
+    }
+
 if __name__ == "__main__":
     num_classes = 10
 
-    # Инициализация модели
-    model = get_resnet18(num_classes)
-
-    ### L1 = sum(weights)
+    # === Regularizers ===
     regularizer_L1 = HierarchicalRegularizer({
-            "type": "global",
-            "norm": "L1",
-            "lambda": 0.05,
+        "type": "global",
+        "norm": "L1",
+        "lambda": 0.05,
     })
-
-    ### L2 = sum(weights**2)
     regularizer_L2 = HierarchicalRegularizer({
-            "type": "global",
-            "norm": "L2",
-            "lambda": 0.05,
+        "type": "global",
+        "norm": "L2",
+        "lambda": 0.05,
     })
     regularizer_group_lasso = HierarchicalRegularizer({
         "type": "layerwise",
         "groups": "base_level",
-        "norm": "L1",          # L1 по фильтрам
-        "inner_norm": "L2",    # L2 внутри фильтра
-        "lambda": 0.05
+        "norm": "L1",
+        "inner_norm": "L2",
+        "lambda": 0.05,
     })
 
-    regularization_loss_l1 = regularizer_L1.forward(model)
-    regularization_loss_l2 = regularizer_L2.forward(model)
-    regularization_loss_group = regularizer_group_lasso.forward(model)
-
-    # === Dataloader ===
+    # === Datasets ===
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.5,), (0.5,))
     ])
     trainset = torchvision.datasets.CIFAR10('./data', train=True, download=True, transform=transform)
+    testset = torchvision.datasets.CIFAR10('./data', train=False, download=True, transform=transform)
+
     trainloader = DataLoader(trainset, batch_size=64, shuffle=True, num_workers=2)
-    regularizer = regularizer_L1
-    # === Run ===
-    model = model.to(device)
-    train(model, trainloader, epochs=10)
+    testloader = DataLoader(testset, batch_size=64, shuffle=False, num_workers=2)
+
+    # === Benchmark ===
+    benchmarks = {
+        "no_regularizer": None,
+        "L1": regularizer_L1,
+        "L2": regularizer_L2,
+        "group_lasso": regularizer_group_lasso,
+    }
+
+    results = {}
+    for name, reg in benchmarks.items():
+        print(f"\n=== Training with {name} ===")
+        model = get_resnet18(num_classes).to(device)
+        writer = SummaryWriter(f"runs/{name}")
+        train(model, trainloader, regularizer=reg, writer=writer, epochs=10)
+        acc = evaluate(model, testloader)
+        stats = weight_statistics(model)
+
+        writer.add_scalar("Eval/Accuracy", acc, 0)
+        writer.add_scalar("Weights/Zero_fraction", stats["zeros"] / stats["total"], 0)
+        writer.add_scalar(
+            "Weights/Near_zero_fraction",
+            stats["near_zeros"] / stats["total"],
+            0,
+        )
+        writer.close()
+
+        results[name] = {
+            "accuracy": acc,
+            "zero_frac": stats["zeros"] / stats["total"],
+            "near_zero_frac": stats["near_zeros"] / stats["total"],
+        }
+
+    print("\n=== Summary ===")
+    for k, v in results.items():
+        print(f"{k}: accuracy={v['accuracy']:.2f}%, zeros={v['zero_frac']:.4f}, near_zeros={v['near_zero_frac']:.4f}")


### PR DESCRIPTION
## Summary
- extend `train_resnet.py` with new utility functions
- log accuracy and weight statistics for each run
- benchmark multiple regularizers and baseline

## Testing
- `python -m py_compile train_resnet.py`
- `python -m py_compile resnet.py group_loss/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684017d0819883209e2bbf437e5d21e5