### PR TITLE
Add docker-compose config for training

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  grouploss:
+    build: .
+    command: python train_resnet.py
+    volumes:
+      - .:/workspace
+    ports:
+      - "6006:6006"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]


### PR DESCRIPTION
## Summary
- provide a docker-compose.yml to run `train_resnet.py` with GPU support

## Testing
- `python test_resnet.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684af77bc2ac83208bf63c78d57d3849